### PR TITLE
Fix error with oh-my-zsh plugin naming

### DIFF
--- a/zsh-goenv.plugin.zsh
+++ b/zsh-goenv.plugin.zsh
@@ -1,0 +1,1 @@
+zsh-goenv.zsh


### PR DESCRIPTION
oh-my-zsh expects to find plugins as
`$HOME/.oh-my-zsh/custom/plugins/<plugin-name>/<plugin-name>.plugin.zsh`
so let's give it a symlink to make things all better.

## Proposed changes

Symlink `zsh-goenv.zsh` to `zsh-goenv.plugin.zsh` to make oh-my-zsh happier.

## Types of changes

What types of changes does your code introduce to Project? _Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.rst) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
  - Not applicable
- [ ] I have added necessary documentation (if appropriate)
  - Not applicable
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

Fixes #67 